### PR TITLE
Customize error message, temporarily disable ignoring lazy loads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ nosetests.xml
 .project
 .pydevproject
 
+# Mypy
+.mypy_cache
+
 # Complexity
 output/*.html
 output/*/index.html

--- a/nplusone/core/listeners.py
+++ b/nplusone/core/listeners.py
@@ -98,6 +98,7 @@ class LazyListener(Listener):
     def handle_lazy(self, caller, args=None, kwargs=None, context=None, ret=None,
                     parser=None):
         model, instance, field = parser(args, kwargs, context)
+        self.ignore = set() # TODO: Better configure what we want to ignore
         if instance in self.loaded and instance not in self.ignore:
             message = LazyLoadMessage(model, field)
             self.parent.notify(message)

--- a/nplusone/core/notifiers.py
+++ b/nplusone/core/notifiers.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import traceback
 
 from nplusone.core import exceptions
 
@@ -49,7 +50,9 @@ class ErrorNotifier(Notifier):
         self.error = config.get('NPLUSONE_ERROR', exceptions.NPlusOneError)
 
     def notify(self, message):
-        raise self.error(message.message)
+        stack = traceback.extract_stack()
+        relevant_frame = [frame for frame in reversed(stack) if 'spark' in frame.filename][0]
+        raise self.error(message.message + ', ' + str(relevant_frame)[len('<FrameSummary '): -1])
 
 
 def init(config):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import re
 from setuptools import setup
 from setuptools import find_packages
 
-
 REQUIRES = [
     'six>=1.9.0',
     'blinker>=1.3',
@@ -35,13 +34,13 @@ def read(fname):
 
 
 setup(
-    name='nplusone',
+    name='nplusone-TrialSpark',
     version=find_version('nplusone/__init__.py'),
     description='Detecting the n+1 queries problem in Python',
     long_description=read('README.rst'),
     author='Joshua Carp',
     author_email='jm.carp@gmail.com',
-    url='https://github.com/jmcarp/nplusone',
+    url='https://github.com/trialspark/nplusone',
     packages=find_packages(exclude=('test*', )),
     package_dir={'nplusone': 'nplusone'},
     include_package_data=True,
@@ -62,5 +61,4 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ],
-    test_suite='tests'
-)
+    test_suite='tests')


### PR DESCRIPTION
Beginning experimentation. This change adds the newest part of the stack trace to the error message, and prevents ignoring names when handling lazy loads, since names seemed to be getting erroneously ignored.